### PR TITLE
Update Links to `myst` Format

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -90,6 +90,9 @@ sphinx:
       launch_buttons:
         colab_url                 : https://colab.research.google.com
     intersphinx_mapping:
+      pyprog:
+        - https://python-programming.quantecon.org/
+        - null
       intro: 
         - https://intro.quantecon.org/
         - null

--- a/lectures/exchangeable.md
+++ b/lectures/exchangeable.md
@@ -549,7 +549,7 @@ assumptions about nature's choice of distribution, namely
 - that nature permanently draws from $G$
 
 Outcomes depend on a peculiar property of likelihood ratio processes  discussed in
-[this lecture](https://python-advanced.quantecon.org/additive_functionals.html).
+{doc}`this lecture <tools:additive_functionals>`.
 
 To proceed, we create some Python code.
 

--- a/lectures/hoist_failure.md
+++ b/lectures/hoist_failure.md
@@ -33,8 +33,8 @@ We'll use the following concepts and tools:
 * a hierarchical probability model for describing uncertain probabilities
 * Fourier transforms and inverse Fourier tranforms as efficient ways of computing convolutions of sequences
 
-For more about Fourier transforms see this quantecon lecture [Circulant Matrices](https://python.quantecon.org/eig_circulant.html)
-as well as these  lecture  [Covariance Stationary Processes](https://python-advanced.quantecon.org/arma.html) and [Estimation of Spectra](https://python-advanced.quantecon.org/estspec.html).
+For more about Fourier transforms see this quantecon lecture {doc}`Circulant Matrices <tools:eig_circulant>`
+as well as these  lecture  {doc}`Covariance Stationary Processes <tools:arma>` and {doc}`Estimation of Spectra <tools:estspec>`.
 
 
 

--- a/lectures/likelihood_ratio_process.md
+++ b/lectures/likelihood_ratio_process.md
@@ -691,5 +691,5 @@ plt.plot(range(T), np.sum(l_seq_h > 10000, axis=0) / N)
 Likelihood processes play an important role in Bayesian learning, as described in {doc}`this lecture <likelihood_bayes>`
 and as applied in {doc}`this lecture <dynam:odu>`.
 
-Likelihood ratio processes appear again in [this lecture](https://python-advanced.quantecon.org/additive_functionals.html), which contains another illustration
+Likelihood ratio processes appear again in {doc}`this lecture <tools:additive_functionals>`, which contains another illustration
 of the **peculiar property** of likelihood ratio processes described above.

--- a/lectures/ols.md
+++ b/lectures/ols.md
@@ -636,7 +636,7 @@ significant, indicating $avexpr_i$ is endogenous.
 
 The OLS parameter $\beta$ can also be estimated using matrix
 algebra and `numpy` (you may need to review the
-[numpy](https://python-programming.quantecon.org/numpy.html) lecture to
+{doc}`numpy <pyprog:numpy>` lecture to
 complete this exercise).
 
 The linear equation we want to estimate is (written in matrix form)

--- a/lectures/pandas_panel.md
+++ b/lectures/pandas_panel.md
@@ -29,7 +29,7 @@ kernelspec:
 
 ## Overview
 
-In an [earlier lecture on pandas](https://python-programming.quantecon.org/pandas.html), we looked at working with simple data sets.
+In an {doc}`earlier lecture on pandas <pyprog:pandas>`, we looked at working with simple data sets.
 
 Econometricians often need to work with more complex data sets, such as panels.
 

--- a/lectures/troubleshooting.md
+++ b/lectures/troubleshooting.md
@@ -33,7 +33,7 @@ The basic assumption of the lectures is that code in a lecture should execute wh
 1. it is executed in a Jupyter notebook and
 1. the notebook is running on a machine with the latest version of Anaconda Python.
 
-You have installed Anaconda, haven't you, following the instructions in [this lecture](https://python-programming.quantecon.org/getting_started.html)?
+You have installed Anaconda, haven't you, following the instructions in {doc}`this lecture <pyprog:getting_started>`?
 
 Assuming that you have, the most common source of problems for our readers is that their Anaconda distribution is not up to date.
 

--- a/lectures/wald_friedman.md
+++ b/lectures/wald_friedman.md
@@ -140,7 +140,7 @@ random variables is also independently and identically distributed (IID).
 
 But the observer does not know which of the two distributions generated the sequence.
 
-For reasons explained in  [Exchangeability and Bayesian Updating](https://python.quantecon.org/exchangeable.html), this means that the sequence is not
+For reasons explained in  {doc}`Exchangeability and Bayesian Updating <stats:exchangeable>`, this means that the sequence is not
 IID.
 
 The observer has something to learn, namely, whether the observations are drawn from  $f_0$ or from $f_1$.
@@ -937,7 +937,7 @@ Here is how Wald introduces the notion of a sequential test
 > observations.
 
 [^f1]: The decision maker acts as if he believes that the sequence of random variables
-$[z_{0}, z_{1}, \ldots]$ is *exchangeable*.  See [Exchangeability and Bayesian Updating](https://python.quantecon.org/exchangeable.html) and
+$[z_{0}, z_{1}, \ldots]$ is *exchangeable*.  See {doc}`Exchangeability and Bayesian Updating <stats:exchangeable>` and
 {cite}`Kreps88` chapter 11, for  discussions of exchangeability.
 
 ## Sequels


### PR DESCRIPTION
This completes the first stage of https://github.com/QuantEcon/meta/issues/119