### PR TITLE
MAINT: Focus on JAX support [bayes_nonconj], CUDA=12.3.1

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -27,7 +27,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-11.8.0-anaconda-2023-09-py311
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.3.1-anaconda-2023-09-py311
       options: --gpus all
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-11.8.0-anaconda-2023-09-py311
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.3.1-anaconda-2023-09-py311
       options: --gpus all
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-11.8.0-anaconda-2023-09-py311
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.3.1-anaconda-2023-09-py311
       options: --gpus all
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR

- [x] removes pytorch and focuses on `jax` as per #15 
- [x] updates to CUDA=12.3.1