### PR TITLE
MAINT: move pandas_panel to after ols

### DIFF
--- a/lectures/_toc.yml
+++ b/lectures/_toc.yml
@@ -4,8 +4,8 @@ parts:
 - caption: Elementary Statistics
   numbered: true
   chapters:
-  - file: pandas_panel
   - file: ols
+  - file: pandas_panel
   - file: mle
   - file: prob_matrix
   - file: lln_clt


### PR DESCRIPTION
@jstac reported the issue of `pandas` lectures being out of order. 

This PR addresses this.