### PR TITLE
MAINT: remove %matplotlib inline and remove contents directives

### DIFF
--- a/lectures/exchangeable.md
+++ b/lectures/exchangeable.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Exchangeability and Bayesian Updating
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This lecture studies  learning

--- a/lectures/imp_sample.md
+++ b/lectures/imp_sample.md
@@ -13,10 +13,6 @@ kernelspec:
 
 # Computing Mean of a Likelihood Ratio Process
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 In  {doc}`this lecture <likelihood_ratio_process>` we described a peculiar property of a likelihood ratio process, namely, that it's mean equals one for all $t \geq 0$ despite it's converging to zero almost surely.

--- a/lectures/likelihood_ratio_process.md
+++ b/lectures/likelihood_ratio_process.md
@@ -20,11 +20,6 @@ kernelspec:
 
 # Likelihood Ratio Processes
 
-```{contents} Contents
-:depth: 2
-```
-
-
 ## Overview
 
 This lecture describes likelihood ratio processes and some of their uses.

--- a/lectures/lln_clt.md
+++ b/lectures/lln_clt.md
@@ -26,10 +26,6 @@ kernelspec:
 ```{index} single: Central Limit Theorem
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This lecture illustrates two of the most important theorems of probability and statistics: The

--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -19,10 +19,6 @@ kernelspec:
 
 # Maximum Likelihood Estimation
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 In a {doc}`previous lecture <ols>`, we estimated the relationship between

--- a/lectures/multi_hyper.md
+++ b/lectures/multi_hyper.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Multivariate Hypergeometric Distribution
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This lecture describes how an  administrator deployed a **multivariate hypergeometric distribution** in order to access the fairness of a procedure for awarding research grants.

--- a/lectures/multivariate_normal.md
+++ b/lectures/multivariate_normal.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Multivariate Normal Distribution
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This lecture describes a workhorse in probability theory, statistics, and economics, namely,

--- a/lectures/navy_captain.md
+++ b/lectures/navy_captain.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Bayesian versus Frequentist Decision Rules
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/ols.md
+++ b/lectures/ols.md
@@ -19,10 +19,6 @@ kernelspec:
 
 # Linear Regression in Python
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/prob_matrix.md
+++ b/lectures/prob_matrix.md
@@ -1320,8 +1320,6 @@ x_mesh, y_mesh = np.meshgrid(x, y, indexing="ij")
 Let's  plot the **population** joint density.
 
 ```{code-cell} ipython3
-# %matplotlib notebook
-
 fig = plt.figure()
 ax = plt.axes(projection='3d')
 
@@ -1330,8 +1328,6 @@ plt.show()
 ```
 
 ```{code-cell} ipython3
-# %matplotlib notebook
-
 fig = plt.figure()
 ax = plt.axes(projection='3d')
 

--- a/lectures/troubleshooting.md
+++ b/lectures/troubleshooting.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Troubleshooting
 
-```{contents} Contents
-:depth: 2
-```
-
 This page is for readers experiencing errors when running the code from the lectures.
 
 ## Fixing Your Local Environment

--- a/lectures/wald_friedman.md
+++ b/lectures/wald_friedman.md
@@ -27,10 +27,6 @@ kernelspec:
 ```{index} single: Models; Sequential analysis
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython3


### PR DESCRIPTION
This PR addresses https://github.com/QuantEcon/meta/issues/134 for this lecture series