### PR TITLE
Update GPU admonition to clarify lectures run on CPUs

### DIFF
--- a/lectures/_admonition/gpu.md
+++ b/lectures/_admonition/gpu.md
@@ -1,9 +1,12 @@
 ```{admonition} GPU
 :class: warning
 
-This lecture was built using a machine with the latest CUDA and CUDANN frameworks installed with access to a GPU.
+This lecture was built using a machine with access to a GPU --- although it will also run without one.
 
-To run this lecture on [Google Colab](https://colab.research.google.com/), click on the "play" icon top right, select Colab, and set the runtime environment to include a GPU.
+[Google Colab](https://colab.research.google.com/) has a free tier with GPUs
+that you can access as follows:
 
-To run this lecture on your own machine, you need to install the software listed following this notice.
+1. Click on the "play" icon top right
+2. Select Colab
+3. Set the runtime environment to include a GPU
 ```


### PR DESCRIPTION
This PR updates the GPU admonition message to clarify that lectures will run without a GPU.

**Changes:**
- Modified `lectures/_admonition/gpu.md` to add "--- although it will also run without one" to the first line
- Incorporates feedback from @jstac
- Harmonizes messaging across lecture repositories

**Impact:**
This provides clearer guidance to users who may not have access to a GPU, ensuring they understand the lectures are still accessible to them.