### PR TITLE
MAINT: migrate RunsOn disk=large → volume=80gb (v3 pilot)

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   cache:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build Project [using jupyter-book]
 on: [pull_request]
 jobs:
   preview:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -2,7 +2,7 @@ name: Build Project on Google Collab (Execution)
 on: [pull_request]
 jobs:
   execution-checks:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=ubuntu24-gpu-x64/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=ubuntu24-gpu-x64/volume=80gb"
     container:
       image: docker://us-docker.pkg.dev/colab-images/public/runtime
       options: --gpus all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Migrates `lecture-stats` to the RunsOn **v3** stack as the migration pilot for QuantEcon/meta#322.

In v3 the `disk=` label is parsed but **ignored** — a runner pointed at a v3 stack with `disk=large` silently boots with the image's *default* root volume, which can fail GPU build jobs with "no space left on device". This PR replaces `disk=large` → `volume=80gb` (the documented v3 equivalent; matches the v2 stack's 80GB large-volume size) across all four RunsOn workflows. The `family=` and `image=` parts are unchanged.

| Workflow | Image | Trigger |
|---|---|---|
| `ci.yml` | `quantecon_ubuntu2404` (custom AMI) | `pull_request` — runs on this PR |
| `collab.yml` | `ubuntu24-gpu-x64` (RunsOn default GPU) | `pull_request` — runs on this PR |
| `cache.yml` | `quantecon_ubuntu2404` | `workflow_dispatch` — validated separately |
| `publish.yml` | `quantecon_ubuntu2404` | tag `publish*` — rides the same proven label |

This must merge together with the v3 cutover (v3 GitHub App now installed on `lecture-stats`, removed from the v2 app) — not before, since v2 doesn't understand `volume=`.

Part of QuantEcon/meta#322

🤖 Generated with [Claude Code](https://claude.com/claude-code)