### PR TITLE
Run GPU builds on-demand: add spot=false to all four workflows

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   cache:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large/spot=false"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build Project [using jupyter-book]
 on: [pull_request]
 jobs:
   preview:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large/spot=false"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -2,7 +2,7 @@ name: Build Project on Google Collab (Execution)
 on: [pull_request]
 jobs:
   execution-checks:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=ubuntu24-gpu-x64/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=ubuntu24-gpu-x64/disk=large/spot=false"
     container:
       image: docker://us-docker.pkg.dev/colab-images/public/runtime
       options: --gpus all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large/spot=false"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
RunsOn defaults to spot pricing, so all four GPU workflows here are exposed to the mid-run reclamation failure diagnosed in QuantEcon/meta#330 — spot capacity reclaimed partway through a 15–25 minute single-GPU notebook build discards the whole run, and the spot saving with it. The org-wide decision there is on-demand for all GPU builds.

This adds `spot=false` to the `runs-on` string in `cache.yml`, `ci.yml`, `collab.yml` and `publish.yml`, matching the pattern already in place in `lecture-jax` and `lecture-python.myst`. Part of finishing the rollout tracked in QuantEcon/meta#330; the audit that found these is QuantEcon/meta#347 (item 1, as corrected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)