### PR TITLE
Add explicit permissions blocks so the default token can drop to read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ on: [pull_request]
 jobs:
   preview:
     runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -3,6 +3,9 @@ on: [pull_request]
 jobs:
   execution-checks:
     runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=ubuntu24-gpu-x64/disk=large"
+    permissions:
+      contents: read
+      pull-requests: write
     container:
       image: docker://us-docker.pkg.dev/colab-images/public/runtime
       options: --gpus all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - 'publish*'
+permissions:
+  contents: write   # peaceiris/actions-gh-pages pushes the built site to gh-pages
+  actions: read     # dawidd6/action-download-artifact reads the cache.yml build artifact
 jobs:
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')


### PR DESCRIPTION
Preparation for QuantEcon/meta#347 item 4 (default workflow token permissions → `read`). This repo currently has **no `permissions:` block in any workflow**, so three workflows rely on the repo-level `write` default; flipping the setting without these blocks would break publishing.

The blocks transcribe what the sibling lecture repos already carry: `ci.yml` and `collab.yml` get `contents: read` + `pull-requests: write` (what `nwtgck/actions-netlify` needs for the preview comment — the same block as `lecture-jax/ci.yml`), and `publish.yml` gets `contents: write` (the `peaceiris/actions-gh-pages` push) + `actions: read` (the `dawidd6/action-download-artifact` cache download — the same scopes `lecture-jax/publish.yml` grants them). `linkcheck.yml` and `cache.yml` write nothing with `GITHUB_TOKEN` and need no block. The notebooks sync uses `QUANTECON_SERVICES_PAT` and is unaffected.

Once a job carries a `permissions:` block, unlisted scopes drop to `none` regardless of the repo default — so this merges safely before or after the settings flip, and it is what makes the flip safe to do.

No conflict with #52 — different lines in the same files; whichever merges second picks both changes up cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)