### PR TITLE
MAINT: consolidate GPU workflow config, bump download-artifact to v21

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   cache:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb/spot=false"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: Build Project [using jupyter-book]
 on: [pull_request]
 jobs:
   preview:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb/spot=false"
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read     # dawidd6/action-download-artifact reads the cache.yml build artifact
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash -l {0}
         run: pip list
       - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v9
+        uses: dawidd6/action-download-artifact@v21
         with:
           workflow: cache.yml
           branch: main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build PDF from LaTeX
         shell: bash -l {0}
         run: |
-          jb build lectures --builder pdflatex --path-output ./ -W --keep-going
+          jb build lectures --builder pdflatex --path-output ./ -n -W --keep-going
           mkdir -p _build/html/_pdf
           cp -u _build/latex/*.pdf _build/html/_pdf
       - name: Upload Execution Reports (LaTeX)

--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -2,7 +2,11 @@ name: Build Project on Google Collab (Execution)
 on: [pull_request]
 jobs:
   execution-checks:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=ubuntu24-gpu-x64/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=ubuntu24-gpu-x64/volume=80gb/spot=false"
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read     # dawidd6/action-download-artifact reads the cache.yml build artifact
     container:
       image: docker://us-docker.pkg.dev/colab-images/public/runtime
       options: --gpus all

--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash -l {0}
         run: pip list
       - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v21
         with:
           workflow: cache.yml
           branch: main

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -27,7 +27,7 @@ jobs:
           environment-file: environment.yml
           activate-environment: quantecon
       - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v9
+        uses: dawidd6/action-download-artifact@v21
         with:
           workflow: cache.yml
           branch: main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
         run: pip list
       # Download Build Cache from cache.yml
       - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v9
+        uses: dawidd6/action-download-artifact@v21
         with:
           workflow: cache.yml
           branch: main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,13 @@ on:
   push:
     tags:
       - 'publish*'
+permissions:
+  contents: write   # peaceiris/actions-gh-pages pushes the built site to gh-pages
+  actions: read     # dawidd6/action-download-artifact reads the cache.yml build artifact
 jobs:
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb/spot=false"
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Consolidates five open PRs into three commits. #51, #52 and #53 all rewrite the same few lines of `ci.yml` and `collab.yml` and conflict pairwise, so landing them separately would have needed two careful conflict resolutions where a careless "take theirs" silently drops `spot=false`. Doing it in one commit resolves that region once.

## What changes

| | Change | Replaces |
|---|---|---|
| 1 | `runs-on`: `disk=large` → `volume=80gb`, plus `spot=false`, on all four GPU workflows | #51, #52 |
| 1 | Explicit `permissions:` blocks so the default token can drop to read | #53 |
| 2 | `dawidd6/action-download-artifact` → `@v21` at all four call sites | #50 |
| 3 | `-n` added to the `ci.yml` PDF build | #25 (partial) |

The four `runs-on` strings now match `lecture-jax` and `lecture-python.myst` byte for byte, allowing for `collab.yml`'s different image (`ubuntu24-gpu-x64`).

## Notes on the judgement calls

**`actions: read` on ci.yml and collab.yml.** #53 declared this only on `publish.yml`, though all three run `dawidd6/action-download-artifact`. It turns out not to be load-bearing: `lecture-jax`'s `ci.yml` runs that action green with `contents: read` and `pull-requests: write` alone, because public-repo tokens can read Actions data without the explicit scope. Added anyway — it is strictly additive, keeps the three files consistent, and removes the reliance on that behaviour.

**v21 rather than dependabot's v14.** v21 has roughly three months of soak against v14's one day, runs on `node24` so it clears the Node 20 deprecation warning that v14 keeps, and is what `lecture-jax` already runs. The input surface this repo uses — `workflow`, `branch`, `name`, `path` — is unchanged across v3, v9, v14 and v21. One real behaviour change: `allow_forks` defaulted `true` in v3 and `false` from v9 on, so `collab.yml` does change. It is inert here because the step pins `branch: main` against an upstream workflow, so the runs being searched are never fork runs.

**The `-n` flag.** `ci.yml`'s PDF build was the only `jb build` in that file without `-n`, while `publish.yml` runs the same pdflatex build with `-n -W`. That gap let a bad cross-reference or missing citation pass the PR check and then fail the tag-only publish build. `cache.yml` also builds HTML without `-n`; left alone deliberately, since that workflow is currently failing and tightening it is a separate change.

## What this does not fix

CI stays red. Both repo-wide breakages are untouched by this PR and are being handled separately: the stale PyTorch nightly index in `ci.yml`'s install step, and `cache.yml` being both auto-disabled for inactivity and failing during notebook execution, so the `build-cache` artifact every other workflow downloads has never existed.

Part of the rollout tracked in QuantEcon/meta#330, with the permissions work from QuantEcon/meta#347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
