### PR TITLE
Add a permissions block to linkcheck.yml, matching the other workflows

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -9,6 +9,9 @@ jobs:
   link-check-linux:
     name: Link Checking (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      actions: read     # dawidd6/action-download-artifact reads the cache.yml build artifact
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Completes the permissions hardening #54 landed for `ci`, `collab` and `publish` — `linkcheck.yml` is the one remaining workflow using `dawidd6/action-download-artifact` without an explicit block. The download works today via public-repo API leniency (the same mechanism the sibling repos' ci workflows rely on), so this is consistency hardening rather than a live fix: `contents: read` + `actions: read`, with the same comment the other blocks carry.

Raised by Copilot's review on the superseded #53 (its other two comments were addressed by #54's consolidated blocks). With this merged, every workflow in the repo that touches the Actions API carries an explicit grant, and the repo-level token default can drop to read with nothing relying on leniency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)