### PR TITLE
FIX: repair the GPU install stack and the build cache

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -31,8 +31,10 @@ jobs:
           pip install pyro-ppl
           pip install "jax[cuda12]==0.7.1"
           pip install numpyro
-          # See the equivalent block in ci.yml for why numpy<2 is load-bearing.
-          pip install "numpy<2" "arviz<1" "pymc<6" "kaleido<1"
+          # See the equivalent block in ci.yml for why the conda stack must be held.
+          python -c "import importlib.metadata as md; d={x.metadata['Name'].lower():x.version for x in md.distributions()}; print('\n'.join(f'{p}=={d[p]}' for p in ('numpy','pandas','scipy') if p in d))" > /tmp/conda-pins.txt
+          cat /tmp/conda-pins.txt
+          pip install --only-binary=:all: -c /tmp/conda-pins.txt "arviz<1" "pymc<6" "kaleido<1"
           python -c "import numpy, numba; assert numpy.__version__.startswith('1.'), numpy.__version__"
           python scripts/test-jax-install.py
       - name: Check nvidia drivers

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -23,8 +23,17 @@ jobs:
       - name: Install JAX, Numpyro
         shell: bash -l {0}
         run: |
-          pip install --upgrade "jax[cuda12-local]"
-          pip install numpyro  
+          # CUDA 12 stack. .github/runs-on.yml pins ami-09baf66e396fa7cfd, a CUDA 12
+          # AMI, so do not move to cu130 / jax[cuda13] without bumping the AMI first.
+          # torch and pyro-ppl were never installed here even though bayes_nonconj.md
+          # imports both -- this workflow has never produced a successful build.
+          pip install torch --index-url https://download.pytorch.org/whl/cu128
+          pip install pyro-ppl
+          pip install "jax[cuda12]==0.7.1"
+          pip install numpyro
+          # See the equivalent block in ci.yml for why numpy<2 is load-bearing.
+          pip install "numpy<2" "arviz<1" "pymc<6" "kaleido<1"
+          python -c "import numpy, numba; assert numpy.__version__.startswith('1.'), numpy.__version__"
           python scripts/test-jax-install.py
       - name: Check nvidia drivers
         shell: bash -l {0}
@@ -45,3 +54,7 @@ jobs:
         with:
           name: build-cache
           path: _build
+          # _config.yml sets execute_notebooks: "cache", so the execution cache
+          # lives in _build/.jupyter_cache. upload-artifact excludes hidden files
+          # by default, which would ship a "cache" containing no cache.
+          include-hidden-files: true

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -34,7 +34,7 @@ jobs:
           # See the equivalent block in ci.yml for why the conda stack must be held.
           python -c "import importlib.metadata as md; d={x.metadata['Name'].lower():x.version for x in md.distributions()}; print('\n'.join(f'{p}=={d[p]}' for p in ('numpy','pandas','scipy') if p in d))" > /tmp/conda-pins.txt
           cat /tmp/conda-pins.txt
-          pip install --only-binary=:all: -c /tmp/conda-pins.txt "arviz<1" "pymc<6" "kaleido<1"
+          pip install --only-binary=:all: -c /tmp/conda-pins.txt "arviz<1" "pymc<6" "kaleido<1" "prettytable<3.18"
           python -c "import numpy, numba; assert numpy.__version__.startswith('1.'), numpy.__version__"
           python scripts/test-jax-install.py
       - name: Check nvidia drivers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,18 @@ jobs:
           pip install pyro-ppl
           pip install "jax[cuda12]==0.7.1"
           pip install numpyro
-          # numpy<2 is load-bearing. anaconda=2024.10 brings numba 0.60.0, which caps
-          # at numpy<2.1, and 9 lectures import numba. "pymc<6" on its own resolves to
-          # pymc 5.28.5 -> pytensor>=2.38.2 -> numpy>=2.0, i.e. numpy 2.4.x. Pinning
-          # numpy<2 makes pip backtrack to pymc 5.25.1 / pytensor 2.31.7 instead.
-          # These also make the notebooks' own unpinned `!pip install` cells no-ops.
-          pip install "numpy<2" "arviz<1" "pymc<6" "kaleido<1"
+          # arviz and pymc are pre-installed at versions the conda stack can carry, so
+          # the notebooks' own unpinned `!pip install arviz pymc` cells become no-ops.
+          # They must not be allowed to move the conda-provided scientific stack: left
+          # free, xarray drags pandas forward, pandas 3.x requires numpy>=2, and pip
+          # backtracks through pandas until it reaches an sdist that fails to build
+          # (the numpy Cython headers need Cython>=3). numpy>=2 would also break numba
+          # 0.60.0, which caps at numpy<2.1 and is imported by 9 lectures.
+          # The constraints file is derived from the env rather than hardcoded so that
+          # bumping anaconda in environment.yml does not silently invalidate it.
+          python -c "import importlib.metadata as md; d={x.metadata['Name'].lower():x.version for x in md.distributions()}; print('\n'.join(f'{p}=={d[p]}' for p in ('numpy','pandas','scipy') if p in d))" > /tmp/conda-pins.txt
+          cat /tmp/conda-pins.txt
+          pip install --only-binary=:all: -c /tmp/conda-pins.txt "arviz<1" "pymc<6" "kaleido<1"
           python -c "import numpy, numba; assert numpy.__version__.startswith('1.'), numpy.__version__"
           python scripts/test-jax-install.py
         # Check nvidia drivers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,19 @@ jobs:
       - name: Install JAX, Numpyro
         shell: bash -l {0}
         run: |
-          pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
+          # CUDA 12 stack. .github/runs-on.yml pins ami-09baf66e396fa7cfd, a CUDA 12
+          # AMI, so do not move to cu130 / jax[cuda13] without bumping the AMI first.
+          pip install torch --index-url https://download.pytorch.org/whl/cu128
           pip install pyro-ppl
-          pip install --upgrade "jax[cuda12-local]"
-          pip install numpyro  
+          pip install "jax[cuda12]==0.7.1"
+          pip install numpyro
+          # numpy<2 is load-bearing. anaconda=2024.10 brings numba 0.60.0, which caps
+          # at numpy<2.1, and 9 lectures import numba. "pymc<6" on its own resolves to
+          # pymc 5.28.5 -> pytensor>=2.38.2 -> numpy>=2.0, i.e. numpy 2.4.x. Pinning
+          # numpy<2 makes pip backtrack to pymc 5.25.1 / pytensor 2.31.7 instead.
+          # These also make the notebooks' own unpinned `!pip install` cells no-ops.
+          pip install "numpy<2" "arviz<1" "pymc<6" "kaleido<1"
+          python -c "import numpy, numba; assert numpy.__version__.startswith('1.'), numpy.__version__"
           python scripts/test-jax-install.py
         # Check nvidia drivers
       - name: nvidia Drivers
@@ -56,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: execution-reports
+          name: execution-reports-notebooks
           path: _build/jupyter/reports
       - name: Build PDF from LaTeX
         shell: bash -l {0}
@@ -68,7 +77,7 @@ jobs:
         uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: execution-reports
+          name: execution-reports-latex
           path: _build/latex/reports
       # Final Build of HTML
       - name: Build HTML
@@ -79,7 +88,7 @@ jobs:
         uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: execution-reports
+          name: execution-reports-html
           path: _build/html/reports
       - name: Preview Deploy to Netlify
         uses: nwtgck/actions-netlify@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,14 @@ jobs:
           # 0.60.0, which caps at numpy<2.1 and is imported by 9 lectures.
           # The constraints file is derived from the env rather than hardcoded so that
           # bumping anaconda in environment.yml does not silently invalidate it.
+          # prettytable<3.18 is a real fix, not hygiene: prettytable declares a bare
+          # "wcwidth" with no floor, so pip accepts conda's wcwidth 0.2.x as satisfying
+          # it, but 3.18.0 calls wcwidth.width(), which only exists from wcwidth 0.3.0.
+          # That AttributeError is what broke prob_matrix.md in run 30975106893.
+          # 3.17.0 still uses wcswidth(), which conda's wcwidth has.
           python -c "import importlib.metadata as md; d={x.metadata['Name'].lower():x.version for x in md.distributions()}; print('\n'.join(f'{p}=={d[p]}' for p in ('numpy','pandas','scipy') if p in d))" > /tmp/conda-pins.txt
           cat /tmp/conda-pins.txt
-          pip install --only-binary=:all: -c /tmp/conda-pins.txt "arviz<1" "pymc<6" "kaleido<1"
+          pip install --only-binary=:all: -c /tmp/conda-pins.txt "arviz<1" "pymc<6" "kaleido<1" "prettytable<3.18"
           python -c "import numpy, numba; assert numpy.__version__.startswith('1.'), numpy.__version__"
           python scripts/test-jax-install.py
         # Check nvidia drivers

--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -37,6 +37,11 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install jupyter-book==1.0.3 quantecon-book-theme==0.8.2 sphinx-tojupyter==0.3.0 sphinxext-rediraffe==0.2.7 sphinxcontrib-youtube==1.3.0 sphinx-togglebutton==0.3.2 arviz sphinx-proof sphinx-exercise sphinx-reredirects
+          # The Colab image ships plotly 5.24.1 and no kaleido, so back_prop.md's
+          # `!pip install kaleido` cell pulls kaleido 1.x, which is incompatible.
+          # Pinning here makes that cell a no-op. Unlike the conda workflows, this
+          # container is a coherent numpy 2.0.2 stack, so it needs no numpy pin.
+          pip install "kaleido<1"
       # Build of HTML (Execution Testing)
       - name: Build HTML
         shell: bash -l {0}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,10 @@ jobs:
           pip install pyro-ppl
           pip install "jax[cuda12]==0.7.1"
           pip install numpyro
-          # See the equivalent block in ci.yml for why numpy<2 is load-bearing.
-          pip install "numpy<2" "arviz<1" "pymc<6" "kaleido<1"
+          # See the equivalent block in ci.yml for why the conda stack must be held.
+          python -c "import importlib.metadata as md; d={x.metadata['Name'].lower():x.version for x in md.distributions()}; print('\n'.join(f'{p}=={d[p]}' for p in ('numpy','pandas','scipy') if p in d))" > /tmp/conda-pins.txt
+          cat /tmp/conda-pins.txt
+          pip install --only-binary=:all: -c /tmp/conda-pins.txt "arviz<1" "pymc<6" "kaleido<1"
           python -c "import numpy, numba; assert numpy.__version__.startswith('1.'), numpy.__version__"
           python scripts/test-jax-install.py
       - name: Check nvidia drivers

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
           # See the equivalent block in ci.yml for why the conda stack must be held.
           python -c "import importlib.metadata as md; d={x.metadata['Name'].lower():x.version for x in md.distributions()}; print('\n'.join(f'{p}=={d[p]}' for p in ('numpy','pandas','scipy') if p in d))" > /tmp/conda-pins.txt
           cat /tmp/conda-pins.txt
-          pip install --only-binary=:all: -c /tmp/conda-pins.txt "arviz<1" "pymc<6" "kaleido<1"
+          pip install --only-binary=:all: -c /tmp/conda-pins.txt "arviz<1" "pymc<6" "kaleido<1" "prettytable<3.18"
           python -c "import numpy, numba; assert numpy.__version__.startswith('1.'), numpy.__version__"
           python scripts/test-jax-install.py
       - name: Check nvidia drivers

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,15 @@ jobs:
       - name: Install JAX, Numpyro
         shell: bash -l {0}
         run: |
-          pip install --upgrade "jax[cuda12-local]"
-          pip install numpyro  
+          # CUDA 12 stack. .github/runs-on.yml pins ami-09baf66e396fa7cfd, a CUDA 12
+          # AMI, so do not move to cu130 / jax[cuda13] without bumping the AMI first.
+          pip install torch --index-url https://download.pytorch.org/whl/cu128
+          pip install pyro-ppl
+          pip install "jax[cuda12]==0.7.1"
+          pip install numpyro
+          # See the equivalent block in ci.yml for why numpy<2 is load-bearing.
+          pip install "numpy<2" "arviz<1" "pymc<6" "kaleido<1"
+          python -c "import numpy, numba; assert numpy.__version__.startswith('1.'), numpy.__version__"
           python scripts/test-jax-install.py
       - name: Check nvidia drivers
         shell: bash -l {0}


### PR DESCRIPTION
Repairs the two breakages that have kept every workflow in this repo red, and verifies the fix by running `cache.yml` to green on this branch — the first successful build in the retained history ([run 30980194673](https://github.com/QuantEcon/lecture-stats/actions/runs/30980194673), 25 lectures executed, 47 MB `build-cache` artifact produced).

## The two root causes

**1. `ci.yml` installed torch from a frozen nightly channel.** `pip install --pre torch torchvision torchaudio --index-url .../nightly/cu128` resolved torch to `2.12.0.dev20260408` while the newest torchvision there pinned `torch==2.12.0.dev20260407`, a wheel since pruned — `ResolutionImpossible`. The channel has been stale since April 2026. Nothing in the book imports torchvision or torchaudio; the only torch consumer is `bayes_nonconj.md` using core tensor ops. Dropped both, moved to the stable cu128 index.

**2. `cache.yml` never installed torch or pyro-ppl**, although `bayes_nonconj.md` imports both. It is the sole producer of the `build-cache` artifact that `ci`, `collab`, `linkcheck` and `publish` all download, so its failure during notebook execution is why all four have been failing at the download step. No `build-cache` artifact has ever existed in this repo.

## What else had to be fixed to get there

Each of these was found by running the build, not by reading it.

**`prettytable<3.18`.** The single lecture that failed on the first green-install run was `prob_matrix.md`, with `AttributeError: module 'wcwidth' has no attribute 'width'`. prettytable declares `Requires-Dist: wcwidth` with no lower bound, so pip accepts anaconda's wcwidth 0.2.x as satisfying it, then installs prettytable 3.18.0 — which switched from `wcswidth()` to `wcwidth.width()`, added only in wcwidth 0.3.0. Verified against the wheels: 3.17.0 uses `wcswidth()`, 3.18.0 uses `wcwidth.width()`. Pinned prettytable rather than upgrading wcwidth, because prettytable is used by two lectures while wcwidth is shared with prompt_toolkit and IPython.

**Holding the conda stack.** An earlier attempt pinned only `numpy<2`. That was too weak: arviz pulls xarray, current xarray wants a pandas newer than conda's 2.2.2, pandas 3.x requires numpy>=2, so pandas became the only thing pip could move — it walked 3.0.5 down to 2.1.0, hit an sdist, and the build died because the numpy Cython headers need Cython>=3 while pandas 2.1.0 pins Cython<3. Now a constraints file generated from the live environment holds numpy/pandas/scipy, so pip backtracks on the arviz/xarray side where wheels exist. `--only-binary=:all:` turns any repeat into an immediate clear error rather than a five-minute compile.

**`include-hidden-files: true` on the cache upload.** `_config.yml` sets `execute_notebooks: "cache"`, so the execution cache lives in `_build/.jupyter_cache` — hidden. `upload-artifact` has excluded hidden files by default since v4.4. Without this the artifact ships with neither `.jupyter_cache` nor `.doctrees`, and every consumer re-executes the whole book. Confirmed present in the produced artifact.

**`jax[cuda12]==0.7.1`.** Moved off `cuda12-local`, which expects a system CUDA install, to the bundled-CUDA variant that lecture-jax runs green on this same AMI. Pinned to 0.7.1 because it is the last release accepting `numpy>=1.26`; unpinned it resolves to 0.11.0, which drags numpy to 2.5.1 and breaks numba 0.60.0 — imported by 9 lectures.

**`kaleido<1` in `collab.yml`.** That job runs in the Colab container, which none of the conda pins reach; it ships plotly 5.24.1 and no kaleido, so `back_prop.md`'s `!pip install kaleido` would pull an incompatible 1.x.

**Unique artifact names in `ci.yml`.** Three report uploads shared the name `execution-reports` in one job, so the second collided with the first exactly when a build failed and the report was most needed. That collision is why the original failure was never diagnosable.

## A note on CUDA 12 vs 13

`.github/runs-on.yml` pins `ami-09baf66e396fa7cfd`. That is lecture-jax's *pre*-CUDA-13 AMI — the siblings moved to `ami-0edec81935264b6d3` in November 2025 and this repo did not, it kept the same image *name*. So `cu130` and `jax[cuda13]`, which the sibling repos now use, would be wrong here until the AMI is bumped. Comments in the install blocks record this.

## What this does not fix

`ci.yml` and `collab.yml` will stay red on this PR. They fail at the artifact download, which cannot succeed until a green `cache.yml` has run **on `main`** — the consumers all pin `branch: main`, and `cache.yml` has no `push` trigger. The sequence after merge is `gh workflow run cache.yml --ref main`, then everything downstream unblocks.

Two builders remain unexercised, since `cache.yml` only builds HTML: the `sphinx-tojupyter` notebook builder and `pdflatex`. Both were tested offline against the pinned toolchain and pass — pdflatex produces a 385-page PDF with zero sphinx warnings — but neither has run in CI. `publish.yml` has never run at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
