### PR TITLE
Repoint the mle.md download link to data-lectures

### DIFF
--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -129,7 +129,7 @@ Let's have a look at the distribution of the data we'll be working with in this 
 
 Treisman's main source of data is *Forbes'* annual rankings of billionaires and their estimated net worth.
 
-The dataset `mle/fp.dta` can be downloaded from [here](https://python.quantecon.org/_static/lecture_specific/mle/fp.dta)
+The dataset `fp.dta` can be downloaded from [here](https://github.com/QuantEcon/data-lectures/raw/main/lectures/fp.dta)
 or its [AER page](https://www.aeaweb.org/articles?id=10.1257/aer.p20161068).
 
 ```{code-cell} python3


### PR DESCRIPTION
`lectures/mle.md:132` links the `fp.dta` download at `https://python.quantecon.org/_static/lecture_specific/mle/fp.dta` — an asset served by **lecture-python.myst's published site**, not by this repo.

That file is being migrated to `QuantEcon/data-lectures` (landed in QuantEcon/data-lectures#79) and will be deleted from `lecture-python.myst` once its repoint publishes, at which point **this link 404s**. This repo runs `linkcheck.yml` on `cron: '0 12 * * *'` — daily — so it would go red within 24 hours of that publish, in a repo that had no part in the migration. Repointing now closes the window rather than waiting for the alarm.

**Nothing a reader downloads changes.** The migrated copy, the published-site copy, and the archived copy this lecture's own code cell reads all hash to `de99b9c0de6fb08cb732e306971ba87a308c5c4ef8ca3ae23fbbb50eabdecd8d` — verified by fetching all three today.

The link also named `mle/fp.dta` inline in the sentence, a path that does not exist in data-lectures' flat published tree, so the filename is corrected alongside the href.

## Not changed, deliberately

The code read at `mle.md:139` fetches the archived `QuantEcon/lecture-python` blob:

```python
df = pd.read_stata('https://github.com/QuantEcon/lecture-python/blob/master/source/_static/lecture_specific/mle/fp.dta?raw=true')
```

That URL still resolves — archived repos serve raw content indefinitely — and is **unaffected by this migration**, which touches `lecture-python.myst`, a different repo. Consolidating it onto `data-lectures` alongside the link above would be a sensible follow-up: it would retire a dependency on an archived repo, and the bytes are identical so the lecture's output would not move. But it changes what this lecture *executes*, so it is left as the maintainers' call rather than folded into a link fix.

The same applies to `lectures/ols.md`, whose five `read_stata` calls also point at the archived repo.

## Context

This is one PR of a cross-repo wave. Data landed in QuantEcon/data-lectures#79; `lecture-python.myst` repoints in QuantEcon/lecture-python.myst#1034. Plan and tracking: QuantEcon/workspace-lectures#39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
